### PR TITLE
Fix exploit being usable in Spigot due to printing to the logger

### DIFF
--- a/src/main/java/me/rhys/fix/spigot/protocol/ProtocolListener.java
+++ b/src/main/java/me/rhys/fix/spigot/protocol/ProtocolListener.java
@@ -30,7 +30,7 @@ public class ProtocolListener {
 
                     // Avoid Log4J Logger
                     System.out.println("[Log4J Fixer] - " + event.getPlayer().getName()
-                            + " tried to exploit using " + message);
+                            + " tried to exploit using " + message.replace("${", "$_{"));
                 }
             }
         });


### PR DESCRIPTION
The Minecraft Server actually redirects all input to System#out and System#err into the logger, so this code didn't block the exploit. Either don't log the message or here I replaced the start of the string to inject an _ and prevent the issue.